### PR TITLE
feat: Update snakemake to v8

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -8,19 +8,20 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aioeasywebdav-2.4.0-pyha770c72_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.9.3-py311h459d7ec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/amply-0.1.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argparse-dataclass-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attmap-0.13.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/bcrypt-4.1.2-py311h46250e7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/binaryornot-0.4.4-py_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto-2.49.0-py_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.77-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.77-pyge310_1234567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hb755f60_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bz2file-0.98-py_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.28.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
@@ -37,26 +38,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-utils-2.11.9-hee58242_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/coincbc-2.10.10-0_metapackage.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/conda-inject-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/connection_pool-0.0.3-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cookiecutter-2.6.0-pyhca7485f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.5-py311h63ff55d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/datrie-0.8.2-py311h459d7ec_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.20.1-py311h38be061_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dpath-2.1.6-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dropbox-11.36.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eido-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filechunkio-1.8-py_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.1-py311h459d7ec_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ftputil-5.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.18.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/google-api-python-client-2.125.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.29.0-pyhca7485f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/google-auth-httplib2-0.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/google-cloud-core-2.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/google-cloud-storage-2.16.0-pyhca7485f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.1.2-py311h9b08b9c_5.conda
@@ -64,9 +60,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-1.63.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.62.1-py311ha6695c7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/htcondor-classads-23.5.3-h1bc8f3f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/httplib2-0.22.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyhd8ed1ab_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/immutables-0.20-py311h459d7ec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.3-pyhd8ed1ab_0.conda
@@ -100,7 +96,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.26-pthreads_h413a1c8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h5a48ba9_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_5.conda
@@ -116,19 +111,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4.20240210-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/oauth2client-4.1.3-py_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.1-py311h320fe9a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.42-hcad00b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/peppy-0.40.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plac-1.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-py_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prettytable-3.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/proto-plus-1.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.25.3-py311h7b78aeb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.8-py311h459d7ec_0.conda
@@ -137,17 +128,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-modules-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pynacl-1.5.0-py311h459d7ec_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pysftp-0.2.9-py_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.8-hab00c5b_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-htcondor-23.5.3-py311h01e4ee6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-irodsclient-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-slugify-8.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
@@ -166,14 +154,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scitokens-cpp-1.0.2-haea88ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sed-4.8-he412f7d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-8.0.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/slacker-0.14.0-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/slack-sdk-3.27.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/slack_sdk-3.27.1-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-3.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-7.32.4-hdfd78af_1.tar.bz2
-      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-7.32.4-pyhdfd78af_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/stone-3.3.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-8.10.6-hdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.17.1-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-executor-plugins-9.1.0-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.0.0-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-3.1.1-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-8.10.6-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/stopit-1.1.2-py_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/text-unidecode-1.3-pyhd8ed1ab_1.conda
@@ -183,14 +174,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/toposort-1.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.10.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.10.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ubiquerg-0.7.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/uritemplate-4.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/veracitools-0.1.3-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py311h459d7ec_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
@@ -207,17 +195,18 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aioeasywebdav-2.4.0-pyha770c72_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.9.3-py311h459d7ec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/amply-0.1.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argparse-dataclass-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attmap-0.13.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/bcrypt-4.1.2-py311h46250e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boto-2.49.0-py_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.77-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.77-pyge310_1234567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hb755f60_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bz2file-0.98-py_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.28.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
@@ -232,25 +221,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-utils-2.11.9-hee58242_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/coincbc-2.10.10-0_metapackage.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/conda-inject-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/connection_pool-0.0.3-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.5-py311h63ff55d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/datrie-0.8.2-py311h459d7ec_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.20.1-py311h38be061_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dpath-2.1.6-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dropbox-11.36.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eido-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filechunkio-1.8-py_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.1-py311h459d7ec_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ftputil-5.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.18.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/google-api-python-client-2.125.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.29.0-pyhca7485f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/google-auth-httplib2-0.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/google-cloud-core-2.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/google-cloud-storage-2.16.0-pyhca7485f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.1.2-py311h9b08b9c_5.conda
@@ -258,9 +242,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-1.63.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.62.1-py311ha6695c7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/htcondor-classads-23.5.3-h1bc8f3f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/httplib2-0.22.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyhd8ed1ab_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/immutables-0.20-py311h459d7ec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.3-pyhd8ed1ab_0.conda
@@ -294,7 +278,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.26-pthreads_h413a1c8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h5a48ba9_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_5.conda
@@ -310,19 +293,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4.20240210-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/oauth2client-4.1.3-py_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.1-py311h320fe9a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.42-hcad00b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/peppy-0.40.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plac-1.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-py_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prettytable-3.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/proto-plus-1.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.25.3-py311h7b78aeb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.8-py311h459d7ec_0.conda
@@ -331,17 +310,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-modules-0.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pynacl-1.5.0-py311h459d7ec_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pysftp-0.2.9-py_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.8-hab00c5b_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-htcondor-23.5.3-py311h01e4ee6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-irodsclient-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
@@ -358,14 +334,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scitokens-cpp-1.0.2-haea88ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-8.0.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/slacker-0.14.0-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/slack-sdk-3.27.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/slack_sdk-3.27.1-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-3.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-7.32.4-hdfd78af_1.tar.bz2
-      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-7.32.4-pyhdfd78af_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/stone-3.3.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-8.10.6-hdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.17.1-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-executor-plugins-9.1.0-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.0.0-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-3.1.1-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-8.10.6-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/stopit-1.1.2-py_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/throttler-1.2.2-pyhd8ed1ab_0.conda
@@ -373,14 +352,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/toposort-1.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.10.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.10.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ubiquerg-0.7.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/uritemplate-4.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/veracitools-0.1.3-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py311h459d7ec_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
@@ -419,22 +395,6 @@ packages:
   license_family: BSD
   size: 23621
   timestamp: 1650670423406
-- kind: conda
-  name: aioeasywebdav
-  version: 2.4.0
-  build: pyha770c72_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/aioeasywebdav-2.4.0-pyha770c72_0.tar.bz2
-  sha256: 6b4ad9e87fe69564f50f6aab77d03b506996d7ca7e5089dd6beb862bb94708d3
-  md5: dd5bf8931da06c21f9ea03e9621acfc7
-  depends:
-  - aiohttp
-  - python >=3.6
-  - setuptools-scm
-  license: ISC
-  size: 12529
-  timestamp: 1636484549358
 - kind: conda
   name: aiohttp
   version: 3.9.3
@@ -505,6 +465,21 @@ packages:
   size: 12840
   timestamp: 1603108499239
 - kind: conda
+  name: argparse-dataclass
+  version: 2.0.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/argparse-dataclass-2.0.0-pyhd8ed1ab_0.conda
+  sha256: 67e8c1fde7cd025bc7b3190b83bfe967099672a2bcff8e6864f52abfcc25769b
+  md5: be47a0ee841e940a9a8eec03c2f776a3
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 12203
+  timestamp: 1691002812997
+- kind: conda
   name: arrow
   version: 1.3.0
   build: pyhd8ed1ab_0
@@ -553,22 +528,6 @@ packages:
   size: 54582
   timestamp: 1704011393776
 - kind: conda
-  name: bcrypt
-  version: 4.1.2
-  build: py311h46250e7_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/bcrypt-4.1.2-py311h46250e7_0.conda
-  sha256: 78119e6cb92e1d9299fff1545d8d5c1863a6719414ace1e040ae0675d006a9dc
-  md5: 16008526cf238deb71d97a1c58a9e850
-  depends:
-  - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: Apache-2.0
-  license_family: Apache
-  size: 579698
-  timestamp: 1702664063938
-- kind: conda
   name: binaryornot
   version: 0.4.4
   build: py_1
@@ -585,6 +544,21 @@ packages:
   license_family: BSD
   size: 378445
   timestamp: 1531097907306
+- kind: conda
+  name: boto
+  version: 2.49.0
+  build: py_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/boto-2.49.0-py_0.tar.bz2
+  sha256: adc54e1d198000dfbf53507af4c831ce6367600fffff50f8f35cab9c2b8cacab
+  md5: eff2d6d409ea32c4ccd7fad21a27989b
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 857723
+  timestamp: 1545692484380
 - kind: conda
   name: boto3
   version: 1.34.77
@@ -641,6 +615,20 @@ packages:
   license_family: MIT
   size: 351340
   timestamp: 1695990160360
+- kind: conda
+  name: bz2file
+  version: '0.98'
+  build: py_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/bz2file-0.98-py_0.tar.bz2
+  sha256: 4f108fa99daad47a6f2dc33a2dc86de5225b36821f142b88e7e7127809beb30f
+  md5: 784154d757e590f1f26c2427207bfe7a
+  depends:
+  - python
+  license: Apache 2.0
+  size: 8826
+  timestamp: 1537460074042
 - kind: conda
   name: bzip2
   version: 1.0.8
@@ -930,6 +918,22 @@ packages:
   size: 25170
   timestamp: 1666700778190
 - kind: conda
+  name: conda-inject
+  version: 1.3.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/conda-inject-1.3.1-pyhd8ed1ab_0.conda
+  sha256: 4949433c906f96323e694d4ee2deb95b5875728df3f7d25512b5ab6b6ae304c5
+  md5: 7368873d3958a2a5ef2cedcaea68528f
+  depends:
+  - python >=3.9.0,<4.0.0
+  - pyyaml >=6.0.0,<7.0.0
+  license: MIT
+  license_family: MIT
+  size: 10211
+  timestamp: 1703111333501
+- kind: conda
   name: configargparse
   version: '1.7'
   build: pyhd8ed1ab_0
@@ -1018,21 +1022,6 @@ packages:
   size: 161497
   timestamp: 1696000813555
 - kind: conda
-  name: defusedxml
-  version: 0.7.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
-  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
-  md5: 961b3a227b437d82ad7054484cfa71b2
-  depends:
-  - python >=3.6
-  license: PSF-2.0
-  license_family: PSF
-  size: 24062
-  timestamp: 1615232388757
-- kind: conda
   name: docutils
   version: 0.20.1
   build: py311h38be061_3
@@ -1062,24 +1051,6 @@ packages:
   license_family: MIT
   size: 21040
   timestamp: 1684714290684
-- kind: conda
-  name: dropbox
-  version: 11.36.2
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/dropbox-11.36.2-pyhd8ed1ab_0.conda
-  sha256: 38f91323172e86380e1f7e10ae2938aa7c564b8c8b3378ca07ebf21ef454c997
-  md5: fca123f91fbe61e0c52a325326f4d8ce
-  depends:
-  - python ==2.7.*|>=3.4
-  - requests >=2.16.2
-  - six >=1.12.0
-  - stone >=2
-  license: MIT
-  license_family: MIT
-  size: 979149
-  timestamp: 1686657624820
 - kind: conda
   name: eido
   version: 0.2.2
@@ -1115,22 +1086,6 @@ packages:
   size: 20551
   timestamp: 1704921321122
 - kind: conda
-  name: filechunkio
-  version: '1.8'
-  build: py_2
-  build_number: 2
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/filechunkio-1.8-py_2.tar.bz2
-  sha256: 14987b0f4e95670b1d16ba7de3feff140d3089bd7e4c7233ca358364217c933e
-  md5: 5e721173512c05bb5973ceb5616f8c03
-  depends:
-  - python
-  license: MIT
-  license_family: MIT
-  size: 5058
-  timestamp: 1531606890500
-- kind: conda
   name: frozenlist
   version: 1.4.1
   build: py311h459d7ec_0
@@ -1146,21 +1101,6 @@ packages:
   license_family: APACHE
   size: 60669
   timestamp: 1702645612671
-- kind: conda
-  name: ftputil
-  version: 5.1.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ftputil-5.1.0-pyhd8ed1ab_0.conda
-  sha256: 4ecf6ccfb3e008f5401fcaef97e62fbe8bb59d6bfc3b62aa330ffa183a4b96a8
-  md5: 33531fd156b65cd5e38c401f6c1d3fc8
-  depends:
-  - python >=3.6
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 46749
-  timestamp: 1704576673582
 - kind: conda
   name: gitdb
   version: 4.0.11
@@ -1215,25 +1155,6 @@ packages:
   size: 84888
   timestamp: 1711095333724
 - kind: conda
-  name: google-api-python-client
-  version: 2.125.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/google-api-python-client-2.125.0-pyhd8ed1ab_0.conda
-  sha256: 30a58f9f41b5cffc641fbc38140f10e636a287ea42af393d338fddfbc10e00ae
-  md5: 2920328464f304ee289b492fa351ef12
-  depends:
-  - google-api-core >=1.31.5,<3.0.0.dev0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0
-  - google-auth >=1.32.0,<3.0.0.dev0,!=2.24.0,!=2.25.0
-  - google-auth-httplib2 >=0.2.0,<1.0.0
-  - httplib2 >=0.19.0,<1.dev0
-  - python >=3.7
-  - uritemplate >=3.0.1,<5
-  license: Apache-2.0 and MIT
-  size: 6353128
-  timestamp: 1712116187342
-- kind: conda
   name: google-auth
   version: 2.29.0
   build: pyhca7485f_0
@@ -1256,23 +1177,6 @@ packages:
   license_family: Apache
   size: 106600
   timestamp: 1711011268970
-- kind: conda
-  name: google-auth-httplib2
-  version: 0.2.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-httplib2-0.2.0-pyhd8ed1ab_0.conda
-  sha256: ead8e77d518f09fdc5a0f0c0e382c51e292d5eeb758847bc7835bf87f0d57fb9
-  md5: 94055b79d31f37866e2dd142eac21fe9
-  depends:
-  - google-auth
-  - httplib2 >=0.19.0
-  - python >=3.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 15005
-  timestamp: 1702435684216
 - kind: conda
   name: google-cloud-core
   version: 2.4.1
@@ -1403,22 +1307,6 @@ packages:
   size: 10911812
   timestamp: 1711728054890
 - kind: conda
-  name: httplib2
-  version: 0.22.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/httplib2-0.22.0-pyhd8ed1ab_0.conda
-  sha256: b3b4205aa0f5017c58a9468e443a187b5c73a3b9f18bae146feceed6c0d4a81a
-  md5: 75362ef538813bab1cfec370bb09e41f
-  depends:
-  - pyparsing >=2.4.2,<4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3
-  - python >=3.6
-  license: MIT
-  license_family: MIT
-  size: 94812
-  timestamp: 1679483627678
-- kind: conda
   name: humanfriendly
   version: '10.0'
   build: pyhd8ed1ab_6
@@ -1450,6 +1338,23 @@ packages:
   license_family: BSD
   size: 50124
   timestamp: 1701027126206
+- kind: conda
+  name: immutables
+  version: '0.20'
+  build: py311h459d7ec_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/immutables-0.20-py311h459d7ec_1.conda
+  sha256: 530681d1eae71623441fac06e9102d774947faecf29c3c3df5556482441205ea
+  md5: bb01a7b95e3358325b36a539d3e03aab
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 54330
+  timestamp: 1695646905280
 - kind: conda
   name: importlib_resources
   version: 6.4.0
@@ -2036,20 +1941,6 @@ packages:
   size: 232603
   timestamp: 1708946763521
 - kind: conda
-  name: libsodium
-  version: 1.0.18
-  build: h36c2ea0_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
-  sha256: 53da0c8b79659df7b53eebdb80783503ce72fb4b10ed6e9e05cc0e9e4207a130
-  md5: c3788462a6fbddafdb413a9f9053e58d
-  depends:
-  - libgcc-ng >=7.5.0
-  license: ISC
-  size: 374999
-  timestamp: 1605135674116
-- kind: conda
   name: libsqlite
   version: 3.45.2
   build: h2797004_0
@@ -2289,26 +2180,6 @@ packages:
   size: 8065890
   timestamp: 1707225944355
 - kind: conda
-  name: oauth2client
-  version: 4.1.3
-  build: py_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/oauth2client-4.1.3-py_0.tar.bz2
-  sha256: ed079fbccfe181b989a20d02988bd47284af777387ed8020bb021705ff7c0956
-  md5: aafb86ecdbfea40c909719e3a6c72a04
-  depends:
-  - httplib2 >=0.9.1
-  - pyasn1 >=0.1.7
-  - pyasn1-modules >=0.0.5
-  - python
-  - rsa >=3.1.4
-  - six >=1.6.1
-  license: Apache 2.0
-  license_family: Apache
-  size: 67499
-  timestamp: 1549161773242
-- kind: conda
   name: openssl
   version: 3.2.1
   build: hd590300_1
@@ -2362,24 +2233,6 @@ packages:
   license_family: BSD
   size: 15775689
   timestamp: 1708709340605
-- kind: conda
-  name: paramiko
-  version: 3.4.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-3.4.0-pyhd8ed1ab_0.conda
-  sha256: 2e66359261954a79b66858c30e69ea6dd4380bf8bd733940527386b25e31dd13
-  md5: a5e792523b028b06d7ce6e65a6cd4a33
-  depends:
-  - bcrypt >=3.2
-  - cryptography >=3.3
-  - pynacl >=1.5
-  - python >=3.6
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 160045
-  timestamp: 1703016056314
 - kind: conda
   name: pcre2
   version: '10.42'
@@ -2477,40 +2330,6 @@ packages:
   license_family: MIT
   size: 23384
   timestamp: 1706116931972
-- kind: conda
-  name: ply
-  version: '3.11'
-  build: py_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-py_1.tar.bz2
-  sha256: 2cd6fae8f9cbc806b7f828f006ae4a83c23fac917cacfd73c37ce322d4324e53
-  md5: 7205635cd71531943440fbfe3b6b5727
-  depends:
-  - python
-  license: BSD 3-clause
-  license_family: BSD
-  size: 44837
-  timestamp: 1530963184592
-- kind: conda
-  name: prettytable
-  version: 3.10.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/prettytable-3.10.0-pyhd8ed1ab_0.conda
-  sha256: c4d94dceda8ba9cbd0c2b69f9f561289d8075da959e079a6df4de2017c936c47
-  md5: 418c4ff8499ae0a1139831f3192f5721
-  depends:
-  - python >=3.8
-  - wcwidth
-  constrains:
-  - ptable >=9999
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 30148
-  timestamp: 1708373992849
 - kind: conda
   name: proto-plus
   version: 1.23.0
@@ -2644,26 +2463,6 @@ packages:
   size: 860425
   timestamp: 1700608076927
 - kind: conda
-  name: pynacl
-  version: 1.5.0
-  build: py311h459d7ec_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pynacl-1.5.0-py311h459d7ec_3.conda
-  sha256: 8547795cd19394c953e5f5bd55bbcfd598b96c4bee7fbc48eaf977b42740a3a7
-  md5: 41431936fe7624294df31197ae699c44
-  depends:
-  - cffi >=1.4.1
-  - libgcc-ng >=12
-  - libsodium >=1.0.18,<1.0.19.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - six
-  license: Apache-2.0
-  license_family: Apache
-  size: 1154575
-  timestamp: 1695545029063
-- kind: conda
   name: pyopenssl
   version: 24.0.0
   build: pyhd8ed1ab_0
@@ -2694,23 +2493,6 @@ packages:
   license_family: MIT
   size: 89455
   timestamp: 1709721146886
-- kind: conda
-  name: pysftp
-  version: 0.2.9
-  build: py_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pysftp-0.2.9-py_1.tar.bz2
-  sha256: 8aa6c018926587e8ceefd09910a32df54dc78976ce949d2fa8f4a7d025f1b86e
-  md5: 3172621a36e00ef8711a393784d8fa7f
-  depends:
-  - paramiko >=1.17.0
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 15515
-  timestamp: 1531148133749
 - kind: conda
   name: pysocks
   version: 1.7.1
@@ -2832,24 +2614,6 @@ packages:
   license_family: APACHE
   size: 9850550
   timestamp: 1711728387118
-- kind: conda
-  name: python-irodsclient
-  version: 2.0.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/python-irodsclient-2.0.0-pyhd8ed1ab_0.conda
-  sha256: 67e413cefecd94a3964955608a98ab1a47a9cb895a96d28c78ac6862b1874d8d
-  md5: 4e234c0eb61029db6053e420f08b8085
-  depends:
-  - defusedxml
-  - prettytable >=0.7.2
-  - python ==2.7.*|>=3.6
-  - six >=1.10.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 172042
-  timestamp: 1707795047460
 - kind: conda
   name: python-slugify
   version: 8.0.4
@@ -3147,26 +2911,6 @@ packages:
   size: 471183
   timestamp: 1710344615844
 - kind: conda
-  name: setuptools-scm
-  version: 8.0.4
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-8.0.4-pyhd8ed1ab_1.conda
-  sha256: 5b0ae59e7580f8a5acc07a8390181ed63e5fdf891b9100186fee9e864bbf390c
-  md5: a1986ad21c766ff22f7bae93f0641020
-  depends:
-  - packaging >=20.0
-  - python >=3.8
-  - setuptools >=45
-  - tomli >=1.0.0
-  - typing-extensions
-  license: MIT
-  license_family: MIT
-  size: 36626
-  timestamp: 1711030572641
-- kind: conda
   name: six
   version: 1.16.0
   build: pyh6c4a22f_0
@@ -3182,37 +2926,55 @@ packages:
   size: 14259
   timestamp: 1620240338595
 - kind: conda
-  name: slacker
-  version: 0.14.0
-  build: py_0
+  name: slack-sdk
+  version: 3.27.1
+  build: pyha770c72_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/slacker-0.14.0-py_0.tar.bz2
-  sha256: 538123085acedfca171b979eab88674c0fa2ffc9879ff62fe8c57484f8743940
-  md5: ea6b3b3b8babd487cdbcccb7f42c2ccf
-  depends:
-  - python
-  - requests
-  license: Apache-2.0
-  license_family: Apache
-  size: 15628
-  timestamp: 1582919104532
-- kind: conda
-  name: smart_open
-  version: 7.0.4
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.0.4-pyhd8ed1ab_0.conda
-  sha256: c298144d1b5035bcdaee2e2b363a7fc29d10707b38c62c717d6cfd0657b601d3
-  md5: 2804ae86934b30c2afbd713d1448afe5
+  url: https://conda.anaconda.org/conda-forge/noarch/slack-sdk-3.27.1-pyha770c72_0.conda
+  sha256: eef481f02eee6fa941b6ac9f378b2bdcdb87ea6d0969da4402beb2f5698efb35
+  md5: e1d72409611620c26128af784a2b7ca9
   depends:
   - python >=3.6
-  - wrapt
   license: MIT
   license_family: MIT
-  size: 51738
-  timestamp: 1711455452855
+  size: 145139
+  timestamp: 1709096580473
+- kind: conda
+  name: slack_sdk
+  version: 3.27.1
+  build: hd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/slack_sdk-3.27.1-hd8ed1ab_0.conda
+  sha256: b172e0b09e4c710f85f488db78628b3bf9a98ff4ac1dcfd19d74edd6d3f8f639
+  md5: a9ad9b35402b72c1b4a0e97acbd668ea
+  depends:
+  - slack-sdk 3.27.1 pyha770c72_0
+  license: MIT
+  license_family: MIT
+  size: 6257
+  timestamp: 1709096585399
+- kind: conda
+  name: smart_open
+  version: 3.0.0
+  build: pyh9f0ad1d_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/smart_open-3.0.0-pyh9f0ad1d_0.tar.bz2
+  sha256: 9556105ddf6756b6c41645585cd5219331192916bf7bdcdcbc0ce495f100f604
+  md5: 650aace1beee9157ea997bb5d03304c6
+  depends:
+  - boto >=2.32
+  - boto3
+  - bz2file
+  - google-cloud-storage
+  - python
+  - requests
+  license: MIT
+  license_family: MIT
+  size: 79185
+  timestamp: 1602159695421
 - kind: conda
   name: smmap
   version: 5.0.0
@@ -3230,90 +2992,135 @@ packages:
   timestamp: 1634310465482
 - kind: conda
   name: snakemake
-  version: 7.32.4
-  build: hdfd78af_1
-  build_number: 1
+  version: 8.10.6
+  build: hdfd78af_0
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/bioconda/noarch/snakemake-7.32.4-hdfd78af_1.tar.bz2
-  sha256: 8dc8f431daec891d6778316327349b753716b86326247e35f3e9e2c0f62d3e24
-  md5: c258081e11b1009312b8ab18cb1efc4a
+  url: https://conda.anaconda.org/bioconda/noarch/snakemake-8.10.6-hdfd78af_0.tar.bz2
+  sha256: 795edffa060fe63af87b61705e3304599cf1557733ef2df53a4b21c01a107339
+  md5: dc7eefd61eb5b6eca94d5fa8ca8825b1
   depends:
-  - aioeasywebdav
-  - boto3
-  - dropbox >=7.2.1
   - eido
-  - filechunkio >=1.6
-  - ftputil >=3.2
-  - google-api-python-client
-  - google-cloud-storage
-  - google-crc32c
-  - oauth2client
   - pandas
   - peppy
   - pygments
-  - pysftp >=0.2.8
-  - python-irodsclient
-  - slacker
-  - snakemake-minimal 7.32.4.*
+  - slack_sdk
+  - snakemake-minimal 8.10.6.*
   license: MIT
-  size: 8949
-  timestamp: 1697534640438
+  size: 8894
+  timestamp: 1712265433718
 - kind: conda
-  name: snakemake-minimal
-  version: 7.32.4
-  build: pyhdfd78af_1
-  build_number: 1
+  name: snakemake-interface-common
+  version: 1.17.1
+  build: pyhdfd78af_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-7.32.4-pyhdfd78af_1.tar.bz2
-  sha256: c16e66dde5c08a2b266d258c654bb80dc5fa51b43d270050afe450fa1c1c9a46
-  md5: 9dea790fb457de73b4ced05ff42c196f
+  url: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.17.1-pyhdfd78af_0.tar.bz2
+  sha256: f2b035ae4a1103b4c7c0c5fd615cb1a7c06ac2086f510b156e8a0195c46b0771
+  md5: 460440ad1e64488ca482652ee5c2bb1a
+  depends:
+  - argparse-dataclass >=2.0.0,<3.0.0
+  - configargparse >=1.7,<2.0
+  - python >=3.8.0,<4.0.0
+  license: MIT
+  license_family: MIT
+  size: 18611
+  timestamp: 1708515147156
+- kind: conda
+  name: snakemake-interface-executor-plugins
+  version: 9.1.0
+  build: pyhdfd78af_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-executor-plugins-9.1.0-pyhdfd78af_0.tar.bz2
+  sha256: 3aa74e255f3b07fff3ca7990a40bbb881e201e8d424097d35accb488a202d215
+  md5: ddbfc4ecc9da0ed82257b40945e50479
+  depends:
+  - argparse-dataclass >=2.0.0,<3.0.0
+  - python >=3.11.0,<4.0.0
+  - snakemake-interface-common >=1.12.0,<2.0.0
+  - throttler >=1.2.2,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 22735
+  timestamp: 1711473816094
+- kind: conda
+  name: snakemake-interface-report-plugins
+  version: 1.0.0
+  build: pyhdfd78af_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.0.0-pyhdfd78af_0.tar.bz2
+  sha256: 581d624c3d5e8bf67638804976ea11426a6f38acec05f5c7b244684e269d5cfa
+  md5: 48807a1a5a669975f09920777152d6ca
+  depends:
+  - python >=3.11.0,<4.0.0
+  - snakemake-interface-common >=1.16.0,<2.0.0
+  license: MIT
+  size: 13255
+  timestamp: 1708336921056
+- kind: conda
+  name: snakemake-interface-storage-plugins
+  version: 3.1.1
+  build: pyhdfd78af_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-3.1.1-pyhdfd78af_0.tar.bz2
+  sha256: 132f3f866a27926344aebbb56b7809967debf44ae105fae2ca5482ddf5d0a4f7
+  md5: ccc7334245500ce7e9da6d8148e9a1f9
+  depends:
+  - python >=3.11.0,<4.0.0
+  - reretry >=0.11.8,<0.12.0
+  - snakemake-interface-common >=1.12.0,<2.0.0
+  - throttler >=1.2.2,<2.0.0
+  - wrapt >=1.15.0,<2.0.0
+  license: MIT
+  size: 18497
+  timestamp: 1709807412355
+- kind: conda
+  name: snakemake-minimal
+  version: 8.10.6
+  build: pyhdfd78af_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-8.10.6-pyhdfd78af_0.tar.bz2
+  sha256: 6a9fc314fbfefd654bf3d78f4fca00a8f3aafec582a6d30033a943344b8b0a3e
+  md5: d580eb1d162d39917b5717cfd55ba738
   depends:
   - appdirs
+  - conda-inject >=1.3.1,<2.0
   - configargparse
   - connection_pool >=0.0.3
   - datrie
   - docutils
+  - dpath >=2.1.6,<3.0.0
   - gitpython
   - humanfriendly
+  - immutables
   - jinja2 >=3.0,<4.0
   - jsonschema
   - nbformat
   - packaging
   - psutil
-  - pulp >=2.0,<2.8.0
-  - python >=3.7,<3.12
+  - pulp >=2.3.1,<2.9
+  - python >=3.11,<3.13
   - pyyaml
   - requests >=2.8.1
   - reretry
-  - smart_open >=3.0
+  - smart_open >=3.0,<4.0
+  - snakemake-interface-common >=1.17.0,<2.0
+  - snakemake-interface-executor-plugins >=9.1.0,<10.0.0
+  - snakemake-interface-report-plugins >=1.0.0,<2.0.0
+  - snakemake-interface-storage-plugins >=3.1.0,<4.0
   - stopit
   - tabulate
   - throttler
-  - toposort >=1.10
+  - toposort >=1.10,<2.0
   - wrapt
   - yte >=1.5.1,<2.0
   license: MIT
-  size: 278078
-  timestamp: 1697534627861
-- kind: conda
-  name: stone
-  version: 3.3.3
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/stone-3.3.3-pyhd8ed1ab_0.conda
-  sha256: ef652424225dc1a31448c6c3d8057ca6fe4f51bf7e2464acd526092bbe8aa82f
-  md5: c0e09b0c216a55b7cc746feab618cd41
-  depends:
-  - ply >=3.4
-  - python >=3.5
-  - six >=1.12.0
-  license: MIT
-  license_family: MIT
-  size: 119199
-  timestamp: 1711732324307
+  size: 218128
+  timestamp: 1712265427588
 - kind: conda
   name: stopit
   version: 1.1.2
@@ -3452,21 +3259,6 @@ packages:
   size: 21769
   timestamp: 1710590028155
 - kind: conda
-  name: typing-extensions
-  version: 4.10.0
-  build: hd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.10.0-hd8ed1ab_0.conda
-  sha256: 0698fe2c4e555fb44c27c60f7a21fa0eea7f5bf8186ad109543c5b056e27f96a
-  md5: 091683b9150d2ebaa62fd7e2c86433da
-  depends:
-  - typing_extensions 4.10.0 pyha770c72_0
-  license: PSF-2.0
-  license_family: PSF
-  size: 10181
-  timestamp: 1708904805365
-- kind: conda
   name: typing_extensions
   version: 4.10.0
   build: pyha770c72_0
@@ -3510,21 +3302,6 @@ packages:
   size: 20627
   timestamp: 1706829714191
 - kind: conda
-  name: uritemplate
-  version: 4.1.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/uritemplate-4.1.1-pyhd8ed1ab_0.tar.bz2
-  sha256: 2c78ed590f77502544adc6df8c2338cd8b59ca98075b3562855f7837f528aa40
-  md5: 0c4beeff1cbaba9b1a494c6b3dfc5bcc
-  depends:
-  - python >=3.6
-  license: Apache-2.0
-  license_family: Apache
-  size: 12252
-  timestamp: 1634152808866
-- kind: conda
   name: urllib3
   version: 2.2.1
   build: pyhd8ed1ab_0
@@ -3557,21 +3334,6 @@ packages:
   license_family: BSD
   size: 6108
   timestamp: 1572717780817
-- kind: conda
-  name: wcwidth
-  version: 0.2.13
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
-  sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
-  md5: 68f0738df502a14213624b288c60c9ad
-  depends:
-  - python >=3.8
-  license: MIT
-  license_family: MIT
-  size: 32709
-  timestamp: 1704731373922
 - kind: conda
   name: wrapt
   version: 1.16.0

--- a/pixi.lock
+++ b/pixi.lock
@@ -160,6 +160,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-3.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-8.10.6-hdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-cluster-generic-1.0.9-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.17.1-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-executor-plugins-9.1.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.0.0-pyhdfd78af_0.tar.bz2
@@ -340,6 +341,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-3.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-8.10.6-hdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-cluster-generic-1.0.9-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.17.1-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-executor-plugins-9.1.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.0.0-pyhdfd78af_0.tar.bz2
@@ -3009,6 +3011,23 @@ packages:
   license: MIT
   size: 8894
   timestamp: 1712265433718
+- kind: conda
+  name: snakemake-executor-plugin-cluster-generic
+  version: 1.0.9
+  build: pyhdfd78af_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-cluster-generic-1.0.9-pyhdfd78af_0.tar.bz2
+  sha256: 38a9a779f242843e94fed34b0fbc0f9be0001f6bd322681c83146186fdd48da6
+  md5: 9b1db7127119f513696d620eefe7bf67
+  depends:
+  - python >=3.11.0,<4.0.0
+  - snakemake-interface-common >=1.13.0,<2.0.0
+  - snakemake-interface-executor-plugins >=9.0.0,<10.0.0
+  license: MIT
+  license_family: MIT
+  size: 13919
+  timestamp: 1710194099964
 - kind: conda
   name: snakemake-interface-common
   version: 1.17.1

--- a/pixi.toml
+++ b/pixi.toml
@@ -22,7 +22,7 @@ snakemake --cores 1 --printshellcmds --software-deployment-method apptainer --sn
 
 [dependencies]
 python = "3.11.*"
-snakemake = "==7.32.4"
+snakemake = "==8.10.6"
 python-htcondor = "==23.5.3"
 
 [feature.cookie.tasks]

--- a/pixi.toml
+++ b/pixi.toml
@@ -24,6 +24,7 @@ snakemake --cores 1 --printshellcmds --software-deployment-method apptainer --sn
 python = "3.11.*"
 snakemake = "==8.10.6"
 python-htcondor = "==23.5.3"
+snakemake-executor-plugin-cluster-generic = "==1.0.9"
 
 [feature.cookie.tasks]
 lxbatch-init = """


### PR DESCRIPTION
* Use the 'config.v8+.yaml' patch to have snakemake v8 work with the
  HTCondor Snakemake profile.
   - c.f. https://github.com/Snakemake-Profiles/htcondor/issues/18
   - Builds on PR https://github.com/matthewfeickert/snakemake-lxplus-example/pull/3
     which added the patch.
* Add snakemake-executor-plugin-cluster-generic which is required for
  snakemake v8+.