### PR TITLE
feat: Remove grid-submit patch in favor of updated Snakemake-Profiles/htcondor

### DIFF
--- a/patches/grid-submit-patch.py
+++ b/patches/grid-submit-patch.py
@@ -1,6 +1,0 @@
-# add kerberos credentials
-col = htcondor.Collector()
-credd = htcondor.Credd()
-credd.add_user_cred(htcondor.CredTypes.Kerberos, None)
-sub["MY.SendCredential"] = "True"
-

--- a/pixi.toml
+++ b/pixi.toml
@@ -36,7 +36,7 @@ mkdir -p .profiles \
 gh:Snakemake-Profiles/htcondor \
 profile_name=lxbatch \
 htcondor_log_dir=$PWD/.condor_jobs \
-location_cern=true\
+location_cern=true \
 && cp patches/config.v8+.yaml .profiles/lxbatch/
 """
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -32,13 +32,12 @@ mkdir -p .profiles \
 && rm -rf .profiles/lxbatch \
 && cookiecutter \
 --no-input \
---checkout fd097135bf3336248ed259e142ee22a7a974c729 \
 --output-dir .profiles/ \
 gh:Snakemake-Profiles/htcondor \
 profile_name=lxbatch \
 htcondor_log_dir=$PWD/.condor_jobs \
-&& cp patches/config.v8+.yaml .profiles/lxbatch/ \
-&& sed --in-place '/schedd = /e cat patches/grid-submit-patch.py' .profiles/lxbatch/grid-submit.py
+location_cern=true\
+&& cp patches/config.v8+.yaml .profiles/lxbatch/
 """
 
 [feature.cookie.dependencies]


### PR DESCRIPTION
* As https://github.com/Snakemake-Profiles/htcondor/pull/22 was accepted, the `grid-submit.py` patch isn't needed anymore as the `location_cern` can be used and is removed.
* Update the installation of Snakemake-Profiles/htcondor to its latest commit.